### PR TITLE
Record and display bank balance history

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 require:
+  - rubocop-capybara
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec

--- a/Gemfile
+++ b/Gemfile
@@ -59,9 +59,10 @@ group :development, :test do
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem 'rspec-rails', '~> 6.0.0'
   gem 'rubocop', '~> 1.39', require: false
-  gem 'rubocop-performance', '~> 1.16.0', require: false
-  gem 'rubocop-rails', '~> 2.18.0', require: false
-  gem 'rubocop-rspec', '~> 2.15.0', require: false
+  gem 'rubocop-capybara', require: false
+  gem 'rubocop-performance', require: false
+  gem 'rubocop-rails', require: false
+  gem 'rubocop-rspec', require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,8 +88,6 @@ GEM
     crass (1.0.6)
     date (3.3.3)
     debug (1.7.1)
-      irb (>= 1.5.0)
-      reline (>= 0.3.1)
     diff-lcs (1.5.0)
     e2mmap (0.1.0)
     erubi (1.12.0)
@@ -100,9 +98,6 @@ GEM
     importmap-rails (1.1.5)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
-    io-console (0.6.0)
-    irb (1.6.3)
-      reline (>= 0.3.0)
     jaro_winkler (1.5.4)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
@@ -187,8 +182,6 @@ GEM
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.7.0)
-    reline (0.3.2)
-      io-console (~> 0.5)
     reverse_markdown (2.1.1)
       nokogiri
     rexml (3.2.5)
@@ -221,6 +214,8 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.27.0)
       parser (>= 3.2.1.0)
+    rubocop-capybara (2.17.1)
+      rubocop (~> 1.41)
     rubocop-performance (1.16.0)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
@@ -228,8 +223,9 @@ GEM
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
-    rubocop-rspec (2.15.0)
+    rubocop-rspec (2.19.0)
       rubocop (~> 1.33)
+      rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
     solargraph (0.48.0)
       backport (~> 1.2)
@@ -297,9 +293,10 @@ DEPENDENCIES
   rails (~> 7.0.4)
   rspec-rails (~> 6.0.0)
   rubocop (~> 1.39)
-  rubocop-performance (~> 1.16.0)
-  rubocop-rails (~> 2.18.0)
-  rubocop-rspec (~> 2.15.0)
+  rubocop-capybara
+  rubocop-performance
+  rubocop-rails
+  rubocop-rspec
   solargraph
   sprockets-rails
   stimulus-rails

--- a/app/controllers/bank_accounts_controller.rb
+++ b/app/controllers/bank_accounts_controller.rb
@@ -12,6 +12,7 @@ class BankAccountsController < ApplicationController
   # GET /bank_accounts/new
   def new
     @bank_account = BankAccount.new
+    @bank_account.build_current_balance
   end
 
   # GET /bank_accounts/1/edit
@@ -62,6 +63,6 @@ class BankAccountsController < ApplicationController
   end
 
   def bank_account_params
-    params.require(:bank_account).permit(:bank, :account, :balance)
+    params.require(:bank_account).permit(:bank, :account, current_balance_attributes: [:id, :balance])
   end
 end

--- a/app/models/bank_account.rb
+++ b/app/models/bank_account.rb
@@ -1,7 +1,18 @@
 class BankAccount < ApplicationRecord
-  monetize :balance_cents
+  has_many :balances, class_name: 'BankAccountBalance', inverse_of: :bank_account, dependent: :destroy
+  has_one :current_balance,
+          -> { order(created_at: :desc) },
+          class_name: 'BankAccountBalance',
+          inverse_of: :bank_account,
+          autosave: true,
+          dependent: :destroy
 
-  validates :bank, presence: true, length: { minimum: 3, maximum: 50 }
-  validates :account, presence: true, length: { minimum: 3, maximum: 50 }
-  validates :balance, presence: true, numericality: true
+  accepts_nested_attributes_for :current_balance
+
+  delegate :balance, to: :current_balance
+
+  validates :bank, presence: true
+  validates :bank, length: { minimum: 3, maximum: 50 }, allow_blank: true
+  validates :account, presence: true
+  validates :account, length: { minimum: 3, maximum: 50 }, allow_blank: true
 end

--- a/app/models/bank_account_balance.rb
+++ b/app/models/bank_account_balance.rb
@@ -1,0 +1,7 @@
+class BankAccountBalance < ApplicationRecord
+  monetize :balance_cents
+
+  belongs_to :bank_account
+
+  validates :balance, presence: true, numericality: true
+end

--- a/app/models/bank_account_balance.rb
+++ b/app/models/bank_account_balance.rb
@@ -4,4 +4,11 @@ class BankAccountBalance < ApplicationRecord
   belongs_to :bank_account
 
   validates :balance, presence: true, numericality: true
+
+  before_update :create_instead_of_update
+
+  def create_instead_of_update
+    self.class.create!(bank_account:, balance_cents:) # creates a new record for the new balance
+    self.balance_cents = balance_cents_was # keeps the original balance in the current record
+  end
 end

--- a/app/views/bank_accounts/_bank_account.json.jbuilder
+++ b/app/views/bank_accounts/_bank_account.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! bank_account, :id, :bank, :account, :balance, :created_at, :updated_at
+json.extract! bank_account, :id, :bank, :account, :current_balance, :created_at, :updated_at
 json.url bank_account_url(bank_account, format: :json)

--- a/app/views/bank_accounts/_form.html.erb
+++ b/app/views/bank_accounts/_form.html.erb
@@ -21,10 +21,12 @@
     <%= form.text_field :account, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
   </div>
 
-  <div class="my-5">
-    <%= form.label :balance %>
-    <%= form.text_field :balance, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
-  </div>
+  <%= form.fields_for :current_balance do |balance_subform| %>
+    <div class="my-5">
+      <%= balance_subform.label :balance %>
+      <%= balance_subform.text_field :balance, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    </div>
+  <% end %>
 
   <div class="inline">
     <%= form.submit class: "rounded-lg py-3 px-5 bg-blue-600 text-white inline-block font-medium cursor-pointer" %>

--- a/app/views/bank_accounts/show.html.erb
+++ b/app/views/bank_accounts/show.html.erb
@@ -1,11 +1,14 @@
-<div class="mx-auto md:w-2/3 w-full flex">
-  <div class="mx-auto">
-    <% if notice.present? %>
-      <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
-    <% end %>
+<div class="mx-auto md:w-2/3 w-full block">
+  <h1 class="font-bold text-4xl"><%= @bank_account.account %></h1>
+  <% if notice.present? %>
+    <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg inline-block" id="notice"><%= notice %></p>
+  <% end %>
 
+  <div class="block my-5">
     <%= render @bank_account %>
+  </div>
 
+  <div class="block my-5">
     <%= link_to 'Edit this bank account', edit_bank_account_path(@bank_account), class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
     <div class="inline-block ml-2">
       <%= button_to 'Delete this bank account',
@@ -15,5 +18,16 @@
                     class: "mt-2 rounded-lg py-3 px-5 bg-red-300 font-medium" %>
     </div>
     <%= link_to 'Back to bank accounts', bank_accounts_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+  </div>
+
+  <div class="block my-5">
+    <h2 class="font-bold text-2xl my-2">Balance history</h2>
+    <ul class="list-disc">
+      <% @bank_account.balances.each do |account_balance| %>
+        <li>
+          <strong class="font-medium mb-1"><%= account_balance.created_at.to_fs(:db) %></strong> - <%= account_balance.balance.format %>
+        </li>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/bank_accounts/show.html.erb
+++ b/app/views/bank_accounts/show.html.erb
@@ -12,7 +12,7 @@
                     bank_account_path(@bank_account),
                     method: :delete,
                     data: {turbo_method: :delete, turbo_confirm: 'Are you sure?'},
-                    class: "mt-2 rounded-lg py-3 px-5 bg-gray-100 font-medium" %>
+                    class: "mt-2 rounded-lg py-3 px-5 bg-red-300 font-medium" %>
     </div>
     <%= link_to 'Back to bank accounts', bank_accounts_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,3 +37,13 @@ en:
       notice: 'Bank account was successfully updated.'
     destroy:
       notice: 'Bank account was successfully deleted.'
+  activerecord:
+    attributes:
+      bank_account/current_balance: # This is how nested attributes are acessed
+        balance: "Account balance"
+    errors:
+      models:
+        bank_account_balance:
+          attributes:
+            balance:
+              not_a_number: "must be a number"

--- a/db/migrate/20221124220314_create_bank_account_balances.rb
+++ b/db/migrate/20221124220314_create_bank_account_balances.rb
@@ -1,0 +1,25 @@
+class CreateBankAccountBalances < ActiveRecord::Migration[7.0]
+  def up
+    create_table :bank_account_balances do |t|
+      t.monetize :balance
+      t.references :bank_account
+      t.datetime :created_at, null: false
+    end
+
+    change_column :bank_account_balances, :balance_cents, :integer, limit: 8
+
+    change_table :bank_accounts, bulk: true do |t|
+      t.remove :balance_cents, :balance_currency
+    end
+  end
+
+  def down
+    drop_table :bank_account_balances
+
+    change_table :bank_accounts do |t|
+      t.monetize :balance
+    end
+
+    change_column :bank_accounts, :balance_cents, :integer, limit: 8
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_19_202337) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_24_220314) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "bank_account_balances", force: :cascade do |t|
+    t.bigint "balance_cents", default: 0, null: false
+    t.string "balance_currency", default: "GBP", null: false
+    t.bigint "bank_account_id"
+    t.datetime "created_at", null: false
+    t.index ["bank_account_id"], name: "index_bank_account_balances_on_bank_account_id"
+  end
 
   create_table "bank_accounts", force: :cascade do |t|
     t.string "bank"
     t.string "account"
-    t.bigint "balance_cents", default: 0, null: false
-    t.string "balance_currency", default: "GBP", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/models/bank_account_balance_spec.rb
+++ b/spec/models/bank_account_balance_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe BankAccountBalance do
+  describe 'validations' do
+    let(:bank_account_balance) { described_class.new }
+
+    it 'validates presence of balance' do
+      bank_account_balance.balance_cents = nil
+      expect(bank_account_balance).not_to be_valid
+      expect(bank_account_balance.errors[:balance]).to include("can't be blank")
+    end
+
+    it 'validates numericality of balance' do
+      bank_account_balance.balance = 'abc'
+      expect(bank_account_balance).not_to be_valid
+      expect(bank_account_balance.errors[:balance]).to include('must be a number')
+    end
+  end
+end

--- a/spec/models/bank_account_balance_spec.rb
+++ b/spec/models/bank_account_balance_spec.rb
@@ -16,4 +16,21 @@ RSpec.describe BankAccountBalance do
       expect(bank_account_balance.errors[:balance]).to include('must be a number')
     end
   end
+
+  describe '#update' do
+    let(:bank_account) { BankAccount.create!(bank: 'BankName', account: 'AccountName') }
+    let(:bank_account_balance) { described_class.create!(balance_cents: 10_000, bank_account:) }
+
+    it 'does not update the balance in the current record' do
+      bank_account_balance.update(balance_cents: 20_000)
+      expect(bank_account_balance.balance_cents).to eq(10_000)
+    end
+
+    it 'creates a new record for the new balance' do
+      bank_account_balance
+      expect { bank_account_balance.update(balance_cents: 20_000) }
+        .to change(described_class, :count).by(1)
+      expect(described_class.last.balance_cents).to eq(20_000)
+    end
+  end
 end

--- a/spec/models/bank_account_spec.rb
+++ b/spec/models/bank_account_spec.rb
@@ -37,17 +37,5 @@ RSpec.describe BankAccount do
       expect(bank_account).not_to be_valid
       expect(bank_account.errors[:account]).to include('is too long (maximum is 50 characters)')
     end
-
-    it 'validates presence of balance' do
-      bank_account.balance_cents = nil
-      expect(bank_account).not_to be_valid
-      expect(bank_account.errors[:balance]).to include("can't be blank")
-    end
-
-    it 'validates numericality of balance' do
-      bank_account.balance = 'abc'
-      expect(bank_account).not_to be_valid
-      expect(bank_account.errors[:balance]).to include('is not a number')
-    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/requests/bank_accounts_spec.rb
+++ b/spec/requests/bank_accounts_spec.rb
@@ -10,18 +10,22 @@ RSpec.describe '/bank_accounts' do
   end
 
   describe 'GET /index' do
-    it 'renders a successful response' do
+    it 'renders a the list of bank accounts' do
       BankAccount.create! valid_attributes
       get bank_accounts_url
       expect(response).to be_successful
+      expect(response.body)
+        .to include('Bank accounts').and include('BankName').and include('AccountName').and include('£300.43')
     end
   end
 
   describe 'GET /show' do
-    it 'renders a successful response' do
+    it 'renders the bank account details' do
       bank_account = BankAccount.create! valid_attributes
       get bank_account_url(bank_account)
       expect(response).to be_successful
+      expect(response.body)
+        .to include('BankName').and include('AccountName').and include('£300.43')
     end
   end
 

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+end

--- a/spec/system/bank_accounts_system_spec.rb
+++ b/spec/system/bank_accounts_system_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe 'Bank Accounts' do
   end
 
   it 'Editing a bank account' do
-    bank_account = BankAccount.create!(bank: 'FooBank', account: 'BarAccount', balance: '462.23')
+    balance = BankAccountBalance.new(balance: '462.23')
+    bank_account = BankAccount.create!(bank: 'FooBank', account: 'BarAccount', current_balance: balance)
     visit '/'
 
     expect(page).to have_css('h1', text: 'Bank accounts')
@@ -69,7 +70,8 @@ RSpec.describe 'Bank Accounts' do
   end
 
   it 'Deleting a bank account' do
-    bank_account = BankAccount.create!(bank: 'FooBank', account: 'BarAccount', balance: '462.23')
+    balance = BankAccountBalance.new(balance: '462.23')
+    bank_account = BankAccount.create!(bank: 'FooBank', account: 'BarAccount', current_balance: balance)
     visit '/'
 
     expect(page).to have_css('h1', text: 'Bank accounts')

--- a/spec/system/bank_accounts_system_spec.rb
+++ b/spec/system/bank_accounts_system_spec.rb
@@ -33,7 +33,12 @@ RSpec.describe 'Bank Accounts' do
 
   it 'Editing a bank account' do
     balance = BankAccountBalance.new(balance: '462.23')
+
+    travel_to Time.zone.local(2023, 3, 10, 1, 4, 44)
     bank_account = BankAccount.create!(bank: 'FooBank', account: 'BarAccount', current_balance: balance)
+    travel_back
+
+    travel_to Time.zone.local(2023, 3, 15, 13, 6, 21)
     visit '/'
 
     expect(page).to have_css('h1', text: 'Bank accounts')
@@ -59,6 +64,8 @@ RSpec.describe 'Bank Accounts' do
     expect(page).to have_css('p', text: 'Bank: NewBank')
     expect(page).to have_css('p', text: 'Account: NewAccount')
     expect(page).to have_css('p', text: 'Balance: £2,000.00')
+    expect(page).to have_css('li', text: '2023-03-10 01:04:44 - £462.23')
+    expect(page).to have_css('li', text: '2023-03-15 13:06:21 - £2,000.00')
 
     click_link 'Back to bank accounts'
 
@@ -67,6 +74,7 @@ RSpec.describe 'Bank Accounts' do
     expect(page).to have_css('p', text: 'Bank: NewBank')
     expect(page).to have_css('p', text: 'Account: NewAccount')
     expect(page).to have_css('p', text: 'Balance: £2,000.00')
+    travel_back
   end
 
   it 'Deleting a bank account' do

--- a/spec/views/bank_accounts/edit.html.erb_spec.rb
+++ b/spec/views/bank_accounts/edit.html.erb_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe 'bank_accounts/edit' do
+  let(:balance) { BankAccountBalance.new(balance: '462.23') }
   let(:bank_account) do
-    BankAccount.create!(bank: 'FooBank', account: 'BarAccount', balance: '462.23')
+    BankAccount.create!(bank: 'FooBank', account: 'BarAccount', current_balance: balance)
   end
 
   before do

--- a/spec/views/bank_accounts/index.html.erb_spec.rb
+++ b/spec/views/bank_accounts/index.html.erb_spec.rb
@@ -1,8 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe 'bank_accounts/index' do
-  let(:first_account) { BankAccount.create!(bank: 'FirstBank', account: 'FirstAccount', balance: '24.32') }
-  let(:second_account) { BankAccount.create!(bank: 'SecondBank', account: 'SecondAccount', balance: '134.00') }
+  let(:first_account) do
+    BankAccount.create!(bank: 'FirstBank',
+                        account: 'FirstAccount',
+                        current_balance: BankAccountBalance.new(balance: '24.32'))
+  end
+
+  let(:second_account) do
+    BankAccount.create!(bank: 'SecondBank',
+                        account: 'SecondAccount',
+                        current_balance: BankAccountBalance.new(balance: '134.00'))
+  end
 
   before do
     assign(:bank_accounts, [first_account, second_account])

--- a/spec/views/bank_accounts/new.html.erb_spec.rb
+++ b/spec/views/bank_accounts/new.html.erb_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'bank_accounts/new' do
-  let(:bank_account) { BankAccount.new }
+  let(:bank_account) { BankAccount.new(current_balance: BankAccountBalance.new) }
 
   it 'displays a new bank account form' do
     assign(:bank_account, bank_account)

--- a/spec/views/bank_accounts/show.html.erb_spec.rb
+++ b/spec/views/bank_accounts/show.html.erb_spec.rb
@@ -1,11 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe 'bank_accounts/show' do
-  let(:bank_account) do
-    BankAccount.create!(bank: 'FooBank',
-                        account: 'BarAccount',
-                        current_balance: BankAccountBalance.new(balance: '3056.84'))
-  end
+  let(:current_balance) { BankAccountBalance.new(balance: '3056.84') }
+  let(:bank_account) { BankAccount.create!(bank: 'FooBank', account: 'BarAccount', current_balance:) }
 
   before do
     assign(:bank_account, bank_account)
@@ -23,5 +20,24 @@ RSpec.describe 'bank_accounts/show' do
     expect(rendered).to have_button('Delete this bank account')
     expect(rendered).to have_link('Edit this bank account', href: edit_bank_account_path(bank_account))
     expect(rendered).to have_link('Back to bank accounts', href: bank_accounts_path)
+  end
+
+  it 'displays the bank account balance history' do
+    travel_to Time.zone.local(2023, 3, 10, 1, 4, 44) do
+      bank_account.current_balance.save!
+    end
+    travel_to Time.zone.local(2023, 3, 9, 13, 3, 12) do
+      bank_account.balances.create!(balance: '200.23')
+    end
+    travel_to Time.zone.local(2023, 3, 8, 12, 1, 3) do
+      bank_account.balances.create!(balance: '3500.45')
+    end
+
+    render
+
+    expect(rendered).to have_content('Balance history')
+    expect(rendered).to have_content('2023-03-10 01:04:44 - £3,056.84')
+    expect(rendered).to have_content('2023-03-09 13:03:12 - £200.23')
+    expect(rendered).to have_content('2023-03-08 12:01:03 - £3,500.45')
   end
 end

--- a/spec/views/bank_accounts/show.html.erb_spec.rb
+++ b/spec/views/bank_accounts/show.html.erb_spec.rb
@@ -1,7 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe 'bank_accounts/show' do
-  let(:bank_account) { BankAccount.create!(bank: 'FooBank', account: 'BarAccount', balance: '3056.84') }
+  let(:bank_account) do
+    BankAccount.create!(bank: 'FooBank',
+                        account: 'BarAccount',
+                        current_balance: BankAccountBalance.new(balance: '3056.84'))
+  end
 
   before do
     assign(:bank_account, bank_account)


### PR DESCRIPTION
When updating the account balance, instead of overriding the previous value, we record a new balance value and associate it with the account as its current balance.

We are displaying the full balance history on the bank account display page.